### PR TITLE
Add output format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ This script will backup your personal Garmin Connect data. All downloaded data w
 
 Usage
 -----
-Usage: `python gcexport.py [how_many] [directory]`
+Usage: `python gcexport.py [how_many] [format] [directory]`
 
 `[how_many]` specifies the number of recent activities you wish to download. You may also specify `all` to download everything. The default is `1`.
+
+`[format]` specifies the desired export format. Valid formats are `gpx`, `tcx` or `original`. The default is `gpx`. When using `original` a zip file is exported that contains the initial input format (e.g. `fit`).
 
 `[directory]` specifies the output directory for the CSV file and the GPX files. The default is a subdirectory with the format `YYYY-MM-DD_garmin_connect_export`. If the directory does not exist, it will be created. If it does exist, activities with existing GPX files will be skipped and the CSV file will be appended to. This should make it easy to restart failed downloads without repeating work.
 


### PR DESCRIPTION
Output format can be set to gpx, tcx or original to allow
export different file formats (e.g. fit).