### PR TITLE
Add JSON export format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Usage: `python gcexport.py [how_many] [format] [directory]`
 
 `[how_many]` specifies the number of recent activities you wish to download. You may also specify `all` to download everything. The default is `1`.
 
-`[format]` specifies the desired export format. Valid formats are `gpx`, `tcx` or `original`. The default is `gpx`. When using `original`, a ZIP file is exported that contains the initial input format (e.g., FIT files).
+`[format]` specifies the desired export format. Valid formats are `gpx`, `tcx`, `original` or `json`. The default is `gpx`. When using `original`, a ZIP file is exported that contains the initial input format (e.g., FIT files). When using `json`, a JSON file is created with all the metadata.
 
 `[directory]` specifies the output directory for the CSV file and the GPX files. The default is a subdirectory with the format `YYYY-MM-DD_garmin_connect_export`. If the directory does not exist, it will be created. If it does exist, activities with existing GPX files will be skipped and the CSV file will be appended to. This should make it easy to restart failed downloads without repeating work. This also allows you to specify a master directory so that this script can be run regularly (to maintain an up-to-date backup) without re-downloading everything.
 


### PR DESCRIPTION
JSON format does not download any file, but saves all the metadata received about activities in a .json file.

This is useful to load all the metadata for analysis using other tools. CSV is good too, but by exporting the raw data as JSON, everything is available and parsing is easy (for example, normalized numbers without units are available).