### PR TITLE
use the newer 1.2 endpoint to download tcx files

### DIFF
--- a/gcexport.py
+++ b/gcexport.py
@@ -92,7 +92,7 @@ url_gc_login     = 'https://sso.garmin.com/sso/login?service=https%3A%2F%2Fconne
 url_gc_post_auth = 'https://connect.garmin.com/post-auth/login?'
 url_gc_search    = 'http://connect.garmin.com/proxy/activity-search-service-1.0/json/activities?'
 url_gc_gpx_activity = 'http://connect.garmin.com/proxy/activity-service-1.1/gpx/activity/'
-url_gc_tcx_activity = 'http://connect.garmin.com/proxy/activity-service-1.1/tcx/activity/'
+url_gc_tcx_activity = 'http://connect.garmin.com/proxy/activity-service-1.2/tcx/activity/'
 url_gc_original_activity = 'http://connect.garmin.com/proxy/download-service/files/activity/'
 
 # Initially, we need to get a valid session cookie, so we pull the login page.


### PR DESCRIPTION
only verified working with tcx files. gpx endpoint still results in HTTP error 410
