### PR TITLE
fixing http status 410 on downloading gpx or tcx

### DIFF
--- a/gcexport.py
+++ b/gcexport.py
@@ -91,8 +91,8 @@ limit_maximum = 100
 url_gc_login     = 'https://sso.garmin.com/sso/login?service=https%3A%2F%2Fconnect.garmin.com%2Fpost-auth%2Flogin&webhost=olaxpw-connect04&source=https%3A%2F%2Fconnect.garmin.com%2Fen-US%2Fsignin&redirectAfterAccountLoginUrl=https%3A%2F%2Fconnect.garmin.com%2Fpost-auth%2Flogin&redirectAfterAccountCreationUrl=https%3A%2F%2Fconnect.garmin.com%2Fpost-auth%2Flogin&gauthHost=https%3A%2F%2Fsso.garmin.com%2Fsso&locale=en_US&id=gauth-widget&cssUrl=https%3A%2F%2Fstatic.garmincdn.com%2Fcom.garmin.connect%2Fui%2Fcss%2Fgauth-custom-v1.1-min.css&clientId=GarminConnect&rememberMeShown=true&rememberMeChecked=false&createAccountShown=true&openCreateAccount=false&usernameShown=false&displayNameShown=false&consumeServiceTicket=false&initialFocus=true&embedWidget=false&generateExtraServiceTicket=false'
 url_gc_post_auth = 'https://connect.garmin.com/post-auth/login?'
 url_gc_search    = 'http://connect.garmin.com/proxy/activity-search-service-1.0/json/activities?'
-url_gc_gpx_activity = 'http://connect.garmin.com/proxy/activity-service-1.1/gpx/activity/'
-url_gc_tcx_activity = 'http://connect.garmin.com/proxy/activity-service-1.1/tcx/activity/'
+url_gc_gpx_activity = 'http://connect.garmin.com/proxy/download-service/export/gpx/activity/'
+url_gc_tcx_activity = 'http://connect.garmin.com/proxy/download-service/export/tcx/activity/'
 url_gc_original_activity = 'http://connect.garmin.com/proxy/download-service/files/activity/'
 
 # Initially, we need to get a valid session cookie, so we pull the login page.


### PR DESCRIPTION
While trying to download my activies in gpx or tcx I got the following message:
```
python gcexport.py --username bla --password blub -c all -f gpx -d 20170125 
Welcome to Garmin Connect Exporter!
Garmin Connect activity: [1540797151] Blubber
	Di, 2017 Jan 24 17:58, 00:28:28, 5,01 Kilometer
	Downloading file...
Traceback (most recent call last):
  File "gcexport.py", line 231, in <module>
    raise Exception('Failed. Got an unexpected HTTP error (' + str(e.code) + ').')
Exception: Failed. Got an unexpected HTTP error (410).
```

Doing some research I found out that the download URLs have changed. This PR will fix it.